### PR TITLE
Publish snapshots to GitHub Packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.project.outputs.version }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Zulu 8
@@ -16,4 +18,23 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn --batch-mode --no-transfer-progress --update-snapshots verify
+      - name: Extract Maven project version
+        run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        id: project
+  publish:
+    needs:
+      - test
+    if: endsWith( needs.test.outputs.version, "-SNAPSHOT" )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Zulu 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Deploy with Maven
+        run: mvn --batch-mode --no-transfer-progress deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
@@ -144,4 +145,17 @@
         <finalName>${project.artifactId}</finalName>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/retailnext/sstemplates</url>
+        </repository>
+    </distributionManagement>
+
+    <scm>
+        <connection>scm:git:https://github.com/retailnext/sstemplates.git</connection>
+        <url>scm:git:https://github.com/retailnext/sstemplates.git</url>
+        <developerConnection>scm:git:https://github.com/retailnext/sstemplates.git</developerConnection>
+    </scm>
 </project>


### PR DESCRIPTION
Releases of non-SNAPSHOT versions will happen as part of a manual workflow
so this workflow only publishes if the version ends in "-SNAPSHOT".