### PR TITLE
Limit jetty-maven-plugin version to <10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "org.eclipse.jetty:jetty-maven-plugin"
+      ],
+      "allowedVersions": "<10"
+    }
   ]
 }


### PR DESCRIPTION
Jetty 10 doesn't work on Java 8 due to the javax->jakarta change.