### PR TITLE
Update to javax.el

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,19 +45,29 @@
         <version>1.9.4</version>
       </dependency>
       <dependency>
-        <groupId>commons-el</groupId>
-        <artifactId>commons-el</artifactId>
-        <version>1.0</version>
+        <groupId>de.odysseus.juel</groupId>
+        <artifactId>juel-api</artifactId>
+        <version>2.2.7</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>4.0.1</version>
+        <groupId>de.odysseus.juel</groupId>
+        <artifactId>juel-impl</artifactId>
+        <version>2.2.7</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet.jsp</groupId>
-        <artifactId>javax.servlet.jsp-api</artifactId>
-        <version>2.3.3</version>
+        <groupId>de.odysseus.juel</groupId>
+        <artifactId>juel-spi</artifactId>
+        <version>2.2.7</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>6.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.servlet.jsp</groupId>
+        <artifactId>jakarta.servlet.jsp-api</artifactId>
+        <version>3.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -72,12 +82,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.17.2</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.17.2</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>
@@ -92,17 +102,17 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.3.28</version>
+        <version>6.0.10</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>5.3.28</version>
+        <version>6.0.10</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>5.3.28</version>
+        <version>6.0.10</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/sstemplates-core/pom.xml
+++ b/sstemplates-core/pom.xml
@@ -21,9 +21,16 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-el</groupId>
-      <artifactId>commons-el</artifactId>
-      <scope>compile</scope>
+      <groupId>de.odysseus.juel</groupId>
+      <artifactId>juel-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.odysseus.juel</groupId>
+      <artifactId>juel-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.odysseus.juel</groupId>
+      <artifactId>juel-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -46,13 +53,13 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet.jsp</groupId>
-      <artifactId>javax.servlet.jsp-api</artifactId>
+      <groupId>jakarta.servlet.jsp</groupId>
+      <artifactId>jakarta.servlet.jsp-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateContext.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateContext.java
@@ -3,89 +3,100 @@ package com.carbonfive.sstemplates;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;
-import javax.servlet.jsp.el.*;
+
+import de.odysseus.el.util.SimpleResolver;
 import org.apache.poi.hssf.usermodel.*;
 import org.apache.poi.ss.util.CellRangeAddress;
 import com.carbonfive.sstemplates.hssf.*;
 import com.carbonfive.sstemplates.tags.SsTemplateTag;
 
-public interface SsTemplateContext extends VariableResolver, FunctionMapper
+import javax.el.*;
+
+public abstract class SsTemplateContext extends ELContext
 {
-  Object setPageVariable( String key, Object value );
+  private final ELResolver resolver;
 
-  void unsetPageVariable( String key, Object oldValue );
+  public SsTemplateContext() {
+    this.resolver = new SimpleResolver();
+  }
 
-  Object getPageVariable( String key );
+  @Override
+  public ELResolver getELResolver() {
+    return this.resolver;
+  }
 
-  Object resolveVariable( String name );
+  public abstract void setPageVariable(String key, Object value);
 
-  HSSFFont createFont( String name, short fontHeight, short color, boolean bold, boolean italic,
+  public abstract void unsetPageVariable( String key, Object oldValue );
+
+  public abstract Object getPageVariable( String key );
+
+  public abstract HSSFFont createFont( String name, short fontHeight, short color, boolean bold, boolean italic,
                        boolean strikeout, byte underline, short typeOffset );
 
-  void incrementCellIndex();
+  public abstract void incrementCellIndex();
 
-  void incrementRowIndex();
+  public abstract void incrementRowIndex();
 
-  CellRangeAddress getRegionForCurrentLocation();
+  public abstract CellRangeAddress getRegionForCurrentLocation();
 
-  String addStyleData( String name, HssfStyleData data );
+  public abstract String addStyleData( String name, HssfStyleData data );
 
-  HSSFCellStyle getNamedStyle( String name )
+  public abstract HSSFCellStyle getNamedStyle( String name )
     throws SsTemplateException;
 
-  HssfStyleData getNamedStyleData( String name )
+  public abstract HssfStyleData getNamedStyleData( String name )
     throws SsTemplateException;
 
-  boolean hasCachedStyleData(String name);
+  public abstract boolean hasCachedStyleData(String name);
 
-  HSSFWorkbook getWorkbook();
+  public abstract HSSFWorkbook getWorkbook();
 
-  void setWorkbook(HSSFWorkbook workbook);
+  public abstract void setWorkbook(HSSFWorkbook workbook);
 
-  HSSFSheet getSheet();
+  public abstract HSSFSheet getSheet();
 
-  void setSheet(HSSFSheet sheet);
+  public abstract void setSheet(HSSFSheet sheet);
 
-  HSSFRow getRow();
+  public abstract HSSFRow getRow();
 
-  void setRow(HSSFRow row);
+  public abstract void setRow(HSSFRow row);
 
-  int getRowIndex();
+  public abstract int getRowIndex();
 
-  void setRowIndex(int rowIndex);
+  public abstract void setRowIndex(int rowIndex);
 
-  int getColumnIndex();
+  public abstract int getColumnIndex();
 
-  void setColumnIndex(int columnIndex);
+  public abstract void setColumnIndex(int columnIndex);
 
-  String getCurrentStyle();
+  public abstract String getCurrentStyle();
 
-  void setCurrentStyle(String currentStyle);
+  public abstract void setCurrentStyle(String currentStyle);
 
-  HssfCellAccumulator getNamedAccumulator(String name);
+  public abstract HssfCellAccumulator getNamedAccumulator(String name);
 
-  void registerMethod(String name, Method m);
+  public abstract void registerMethod(String name, Method m);
 
-  // no prefix support
-  Method resolveFunction(String prefix, String name);
+  public abstract Collection<SsTemplateTag> parseIncludeFile(String parsedTemplate) throws SsTemplateException;
 
-  Collection<SsTemplateTag> parseIncludeFile(String parsedTemplate) throws SsTemplateException;
+  public abstract File findFileInTemplateDirectory(String path);
 
-  public File findFileInTemplateDirectory(String path);
+  public abstract Object getCustomValue(Object key);
 
-  Object getCustomValue(Object key);
+  public abstract void setCustomValue(Object key, Object value);
 
-  void setCustomValue(Object key, Object value);
+  public abstract short getColorIndex(short[] triplet) throws SsTemplateException;
 
-  short getColorIndex(short[] triplet) throws SsTemplateException;
+  public abstract void setBackgroundColor(short[] triplet);
 
-  void setBackgroundColor(short[] triplet);
+  public abstract short[] getBackgroundColor();
 
-  short[] getBackgroundColor();
+  public abstract int getMaxRowIndex();
+  public abstract int getMaxColumnIndex();
 
-  public int getMaxRowIndex();
-  public int getMaxColumnIndex();
+  public abstract void setPageBreaks(int firstPageBreak, int nextPageBreak);
+  public abstract int nextPageBreak(int row);
 
-  public void setPageBreaks(int firstPageBreak, int nextPageBreak);
-  public int nextPageBreak(int row);
+  public abstract ExpressionFactory getExpressionFactory();
 }

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateFunctionMapper.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateFunctionMapper.java
@@ -1,0 +1,23 @@
+package com.carbonfive.sstemplates;
+
+import javax.el.FunctionMapper;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SsTemplateFunctionMapper extends FunctionMapper {
+    Map<String, Method> map = Collections.emptyMap();
+
+    public Method resolveFunction(String prefix, String localName) {
+        return this.map.get(prefix + ":" + localName);
+    }
+
+    public void setFunction(String prefix, String localName, Method method) {
+        if (this.map.isEmpty()) {
+            this.map = new HashMap<>();
+        }
+
+        this.map.put(prefix + ":" + localName, method);
+    }
+}

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateVariableMapper.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/SsTemplateVariableMapper.java
@@ -1,0 +1,70 @@
+package com.carbonfive.sstemplates;
+
+import com.carbonfive.sstemplates.hssf.HssfCellAccumulator;
+
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import javax.el.VariableMapper;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SsTemplateVariableMapper extends VariableMapper {
+    private final Map<String, Object> map = new HashMap<>();
+    private final Map<String, ValueExpression> mapValueExpression = new HashMap<>();
+    private final Map<String, HssfCellAccumulator> accumulatorCache = new HashMap<>();
+    private final ExpressionFactory expressionFactory;
+
+    public SsTemplateVariableMapper(final ExpressionFactory expressionFactory) {
+        this.expressionFactory = expressionFactory;
+        setDefaultVariables();
+    }
+
+    public ValueExpression resolveVariable(String variable) {
+        if ("pageScope".equals(variable)) {
+            return getExpressionFactory().createValueExpression(map, map.getClass());
+        }
+
+        if ("accumulator".equals(variable)) {
+            return getExpressionFactory().createValueExpression(accumulatorCache, accumulatorCache.getClass());
+        }
+
+        return mapValueExpression.get(variable);
+    }
+
+    public void removeVariable(String variable) {
+        this.map.remove(variable);
+        this.mapValueExpression.remove(variable);
+    }
+
+    public ValueExpression setVariable(String variable, ValueExpression expression) {
+        this.map.put(variable, expression.getValue(null));
+        return this.mapValueExpression.put(variable, expression);
+    }
+
+    public void setVariable(String variable, Object value) {
+        if (value == null) {
+            this.mapValueExpression.put(variable, expressionFactory.createValueExpression(null, Object.class));
+        } else {
+            this.mapValueExpression.put(variable, expressionFactory.createValueExpression(value, value.getClass()));
+        }
+        this.map.put(variable, value);
+    }
+
+    public HssfCellAccumulator getAccumulator(final String name) {
+        HssfCellAccumulator acc = accumulatorCache.get(name);
+        if (acc == null) {
+            acc = new HssfCellAccumulator();
+            accumulatorCache.put(name, acc);
+        }
+        return acc;
+    }
+
+    public ExpressionFactory getExpressionFactory() {
+        return this.expressionFactory;
+    }
+
+    private void setDefaultVariables() {
+        setVariable("param", new HashMap<String, Object>());
+        setVariable("paramValues", new HashMap<String, Object>());
+    }
+}

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/ServletSsTemplateProcessor.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/ServletSsTemplateProcessor.java
@@ -2,10 +2,10 @@ package com.carbonfive.sstemplates.servlet;
 
 import com.carbonfive.sstemplates.*;
 import com.carbonfive.sstemplates.tags.*;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.poi.hssf.usermodel.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
 import java.io.*;
 import java.util.*;
 
@@ -47,6 +47,6 @@ public class ServletSsTemplateProcessor
 
   protected SsTemplateServletContext createTemplateContext(HttpServletRequest request, ServletContext context, File templateDir)
   {
-    return new SsTemplateServletContext(request, context, this, templateDir);
+    return new SsTemplateServletContext(request, context, this, templateDir, getExpressionFactory());
   }
 }

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServlet.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServlet.java
@@ -2,8 +2,13 @@ package com.carbonfive.sstemplates.servlet;
 
 import java.io.*;
 import java.util.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.poi.hssf.usermodel.*;
 import com.carbonfive.sstemplates.*;
 import com.carbonfive.sstemplates.tags.*;
@@ -19,7 +24,7 @@ public class SsTemplateServlet extends HttpServlet
 
   private static final String CUSTOM_TAGS_PARAM_KEY = "customTags";
 
-  private ServletContext  context = null;
+  private ServletContext context = null;
   private ServletSsTemplateProcessor processor;
 
   public void init( ServletConfig config ) throws ServletException
@@ -60,7 +65,7 @@ public class SsTemplateServlet extends HttpServlet
     return tags;
   }
 
-  public void doGet( HttpServletRequest request, HttpServletResponse response )
+  public void doGet(HttpServletRequest request, HttpServletResponse response )
     throws ServletException, IOException
   {
     File templateFile = getTemplateFile(request);

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServletContext.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServletContext.java
@@ -1,10 +1,11 @@
 package com.carbonfive.sstemplates.servlet;
 
 import java.io.*;
-import java.util.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
 import com.carbonfive.sstemplates.*;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.el.ExpressionFactory;
 
 /**
  * This class acts as an EL VariableResolver, but does not support the pageContext implicit object.
@@ -14,18 +15,14 @@ import com.carbonfive.sstemplates.*;
 public class SsTemplateServletContext
     extends SsTemplateContextImpl
 {
-  private HttpServletRequest    request         = null;
-  private ServletContext        servletContext  = null;
-  private Map<String, Map<String, Object>> implicitObjects = new HashMap<String, Map<String, Object>>();
+  private final ServletContext servletContext;
 
   public SsTemplateServletContext(HttpServletRequest request, ServletContext context,
-                                  SsTemplateProcessor processor, File templateDir)
+                                  SsTemplateProcessor processor, File templateDir, ExpressionFactory expressionFactory)
   {
-    super(processor, templateDir);
-    this.setRequest(request);
-    this.setServletContext(context);
+    super(processor, templateDir, expressionFactory, new SsTemplateServletVariableMapper(request, context, expressionFactory));
+    this.servletContext = context;
   }
-
 
   public File findFileInTemplateDirectory(String path)
   {
@@ -33,216 +30,6 @@ public class SsTemplateServletContext
     if ( !file.startsWith("/") ) return super.findFileInTemplateDirectory(path);
 
     return new File(servletContext.getRealPath(file));
-  }
-
-  public Object resolveVariable( String name )
-  {
-    if ( "requestScope".equals( name ) )
-      return getRequestScope();
-
-    if ( "sessionScope".equals( name ) )
-      return getSessionScope();
-
-    if ( "applicationScope".equals( name ) )
-      return getApplicationScope();
-
-    if ( "param".equals( name ) )
-      return getParam();
-
-    if ( "paramValues".equals( name ) )
-      return getParamValues();
-
-    if ( "header".equals( name ) )
-      return getHeader();
-
-    if ( "headerValues".equals( name ) )
-      return getHeaderValues();
-
-    if ( "cookie".equals( name ) )
-      return getCookie();
-
-    if ( "initParam".equals( name ) )
-      return getInitParam();
-
-    // otherwise, try to find the name in page, request, session, then application scope
-    if ( getRequest().getAttribute(name) != null )
-      return getRequest().getAttribute(name);
-
-    if (( getRequest().getSession(false) != null ) && ( getRequest().getSession(false).getAttribute(name) != null ))
-      return getRequest().getSession().getAttribute( name );
-
-    if (getServletContext().getAttribute(name) != null)
-      return getServletContext().getAttribute(name);
-
-    return super.resolveVariable(name);
-  }
-
-  private Map<String, Object> getRequestScope()
-  {
-    Map<String, Object> map = implicitObjects.get("requestScope");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getRequest().getAttributeNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getRequest().getAttribute(s) );
-      }
-      implicitObjects.put( "requestScope", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getSessionScope()
-  {
-    Map<String, Object> map = implicitObjects.get("sessionScope");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      if ( getRequest().getSession(false) != null )
-      {
-        for (Enumeration<String> e = getRequest().getSession().getAttributeNames(); e.hasMoreElements();)
-        {
-          String s = e.nextElement();
-          map.put( s, getRequest().getSession().getAttribute(s) );
-        }
-      }
-      implicitObjects.put( "sessionScope", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getApplicationScope()
-  {
-    Map<String, Object> map = implicitObjects.get("applicationScope");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getServletContext().getAttributeNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getServletContext().getAttribute(s) );
-      }
-      implicitObjects.put( "applicationScope", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getParam()
-  {
-    Map<String, Object> map = implicitObjects.get("param");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getRequest().getParameter(s) );
-      }
-      implicitObjects.put( "param", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getParamValues()
-  {
-    Map<String, Object> map = implicitObjects.get("paramValues");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getRequest().getParameterValues(s) );
-      }
-      implicitObjects.put( "paramValues", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getHeader()
-  {
-    Map<String, Object> map = implicitObjects.get("header");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getRequest().getHeaderNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getRequest().getHeader(s) );
-      }
-      implicitObjects.put( "header", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getHeaderValues()
-  {
-    Map<String, Object> map = implicitObjects.get("headerValues");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getRequest().getHeaderNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getRequest().getHeaders(s) );
-      }
-      implicitObjects.put( "headerValues", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getCookie()
-  {
-    Map<String, Object> map = implicitObjects.get("cookies");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      Cookie[] cookies = getRequest().getCookies();
-      for ( int i=0; i < cookies.length; i++ )
-      {
-        if ( ! map.containsKey(cookies[i].getName()) )
-          map.put( cookies[i].getName(), cookies[i] );
-      }
-      implicitObjects.put( "cookies", map );
-    }
-    return map;
-  }
-
-  private Map<String, Object> getInitParam()
-  {
-    Map<String, Object> map = implicitObjects.get("initParam");
-    if ( map == null )
-    {
-      map = new HashMap<String, Object>();
-      for (Enumeration<String> e = getServletContext().getInitParameterNames(); e.hasMoreElements();)
-      {
-        String s = e.nextElement();
-        map.put( s, getServletContext().getInitParameter(s) );
-      }
-      implicitObjects.put( "initParam", map );
-    }
-    return map;
-  }
-
-  public HttpServletRequest getRequest()
-  {
-    return request;
-  }
-
-  public void setRequest(HttpServletRequest request)
-  {
-    this.request = request;
-  }
-
-  public ServletContext getServletContext()
-  {
-    return servletContext;
-  }
-
-  public void setServletContext(ServletContext servletContext)
-  {
-    this.servletContext = servletContext;
   }
 
 }

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServletVariableMapper.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/servlet/SsTemplateServletVariableMapper.java
@@ -1,0 +1,224 @@
+package com.carbonfive.sstemplates.servlet;
+
+import com.carbonfive.sstemplates.SsTemplateVariableMapper;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SsTemplateServletVariableMapper extends SsTemplateVariableMapper {
+    private final Map<String, Map<String, Object>> implicitObjects = new HashMap<>();
+    private final HttpServletRequest request;
+    private final ServletContext servletContext;
+
+    public SsTemplateServletVariableMapper(HttpServletRequest request, ServletContext servletContext, ExpressionFactory expressionFactory) {
+        super(expressionFactory);
+        this.request = request;
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public ValueExpression resolveVariable(String name)
+    {
+        if ("requestScope".equals(name)) {
+            Map<String, Object> requestScope = getRequestScope();
+            return getExpressionFactory().createValueExpression(requestScope, requestScope.getClass());
+        }
+
+        if ("sessionScope".equals(name)) {
+            Map<String, Object> sessionScope = getSessionScope();
+            return getExpressionFactory().createValueExpression(sessionScope, sessionScope.getClass());
+        }
+
+
+        if ("applicationScope".equals(name)) {
+            Map<String, Object> applicationScope = getApplicationScope();
+            return getExpressionFactory().createValueExpression(applicationScope, applicationScope.getClass());
+        }
+
+        if ("param".equals(name)) {
+            Map<String, Object> param = getParam();
+            return getExpressionFactory().createValueExpression(param, param.getClass());
+        }
+
+        if ("paramValues".equals(name)) {
+            Map<String, Object> paramValues = getParamValues();
+            return getExpressionFactory().createValueExpression(paramValues, paramValues.getClass());
+        }
+
+        if ("header".equals(name)) {
+            Map<String, Object> header = getHeader();
+            return getExpressionFactory().createValueExpression(header, header.getClass());
+        }
+
+        if ("headerValues".equals(name)) {
+            Map<String, Object> headerValues = getHeaderValues();
+            return getExpressionFactory().createValueExpression(headerValues, headerValues.getClass());
+        }
+
+        if ("cookie".equals(name)) {
+            Map<String, Object> cookie = getCookie();
+            return getExpressionFactory().createValueExpression(cookie, cookie.getClass());
+        }
+
+        if ("initParam".equals(name)) {
+            Map<String, Object> initParam = getInitParam();
+            return getExpressionFactory().createValueExpression(initParam, initParam.getClass());
+        }
+
+        // otherwise, try to find the name in page, request, session, then application scope
+        if (getRequest().getAttribute(name) != null) {
+            Object value = getRequest().getAttribute(name);
+            return getExpressionFactory().createValueExpression(value, value.getClass());
+        }
+
+
+        if ((getRequest().getSession(false) != null) && (getRequest().getSession(false).getAttribute(name) != null)) {
+            Object value = getRequest().getSession().getAttribute(name);
+            return getExpressionFactory().createValueExpression(value, value.getClass());
+        }
+
+        if (getServletContext().getAttribute(name) != null) {
+            Object value = getServletContext().getAttribute(name);
+            return getExpressionFactory().createValueExpression(value, value.getClass());
+        }
+
+        return super.resolveVariable(name);
+    }
+
+    private Map<String, Object> getRequestScope() {
+        Map<String, Object> map = implicitObjects.get("requestScope");
+        if (map == null) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getRequest().getAttributeNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put(s, getRequest().getAttribute(s));
+            }
+            implicitObjects.put("requestScope", map);
+        }
+        return map;
+    }
+
+    private Map<String, Object> getSessionScope() {
+        Map<String, Object> map = implicitObjects.get("sessionScope");
+        if ( map == null ) {
+            map = new HashMap<>();
+            if ( getRequest().getSession(false) != null ) {
+                for (Enumeration<String> e = getRequest().getSession().getAttributeNames(); e.hasMoreElements();) {
+                    String s = e.nextElement();
+                    map.put( s, getRequest().getSession().getAttribute(s) );
+                }
+            }
+            implicitObjects.put( "sessionScope", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getApplicationScope() {
+        Map<String, Object> map = implicitObjects.get("applicationScope");
+        if ( map == null ) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getServletContext().getAttributeNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getServletContext().getAttribute(s) );
+            }
+            implicitObjects.put( "applicationScope", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getParam() {
+        Map<String, Object> map = implicitObjects.get("param");
+        if ( map == null ) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getRequest().getParameter(s) );
+            }
+            implicitObjects.put( "param", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getParamValues() {
+        Map<String, Object> map = implicitObjects.get("paramValues");
+        if ( map == null ) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getRequest().getParameterValues(s) );
+            }
+            implicitObjects.put( "paramValues", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getHeader() {
+        Map<String, Object> map = implicitObjects.get("header");
+        if ( map == null ) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getRequest().getHeaderNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getRequest().getHeader(s) );
+            }
+            implicitObjects.put( "header", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getHeaderValues() {
+        Map<String, Object> map = implicitObjects.get("headerValues");
+        if ( map == null ) {
+            map = new HashMap<>();
+            for (Enumeration<String> e = getRequest().getHeaderNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getRequest().getHeaders(s) );
+            }
+            implicitObjects.put( "headerValues", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getCookie() {
+        Map<String, Object> map = implicitObjects.get("cookies");
+        if ( map == null ) {
+            map = new HashMap<>();
+            Cookie[] cookies = getRequest().getCookies();
+            for (int i=0; i < cookies.length; i++) {
+                if ( ! map.containsKey(cookies[i].getName()) )
+                    map.put( cookies[i].getName(), cookies[i] );
+            }
+            implicitObjects.put( "cookies", map );
+        }
+        return map;
+    }
+
+    private Map<String, Object> getInitParam() {
+        Map<String, Object> map = implicitObjects.get("initParam");
+        if ( map == null ) {
+            map = new HashMap<String, Object>();
+            for (Enumeration<String> e = getServletContext().getInitParameterNames(); e.hasMoreElements();) {
+                String s = e.nextElement();
+                map.put( s, getServletContext().getInitParameter(s) );
+            }
+            implicitObjects.put( "initParam", map );
+        }
+        return map;
+    }
+
+    public HttpServletRequest getRequest()
+    {
+        return request;
+    }
+
+    public ServletContext getServletContext()
+    {
+        return servletContext;
+    }
+
+}

--- a/sstemplates-core/src/main/java/com/carbonfive/sstemplates/tags/BaseTag.java
+++ b/sstemplates-core/src/main/java/com/carbonfive/sstemplates/tags/BaseTag.java
@@ -1,9 +1,8 @@
 package com.carbonfive.sstemplates.tags;
 
 import com.carbonfive.sstemplates.*;
-import org.apache.commons.el.*;
 
-import javax.servlet.jsp.el.*;
+import javax.el.ValueExpression;
 import java.util.*;
 
 /**
@@ -15,7 +14,6 @@ public abstract class BaseTag implements SsTemplateTag
 {
   List<SsTemplateTag> childTags = new ArrayList<SsTemplateTag>();
   SsTemplateTag parentTag = null;
-  ExpressionEvaluatorImpl evaluator = new ExpressionEvaluatorImpl();
 
   protected void renderChildren( SsTemplateContext context )
     throws SsTemplateException
@@ -57,16 +55,10 @@ public abstract class BaseTag implements SsTemplateTag
   public Object parseExpression( String expression, Class<?> expectedType, SsTemplateContext context )
     throws SsTemplateException
   {
-    if (expression == null) return null;
+    if (expression == null || expression.isBlank()) return null;
 
-    try
-    {
-      return evaluator.evaluate( expression, expectedType, context, context );
-    }
-    catch ( ELException ele )
-    {
-      throw new SsTemplateException( "Error parsing expression " + expression, ele );
-    }
+    ValueExpression valueExpression = context.getExpressionFactory().createValueExpression(context, expression, expectedType);
+    return valueExpression.getValue(context);
   }
 
   public Integer parseInteger( String expression, SsTemplateContext context )

--- a/sstemplates-core/src/test/java/com/carbonfive/sstemplates/SsTemplateTestBase.java
+++ b/sstemplates-core/src/test/java/com/carbonfive/sstemplates/SsTemplateTestBase.java
@@ -2,10 +2,11 @@ package com.carbonfive.sstemplates;
 
 import com.carbonfive.sstemplates.tags.*;
 
-import javax.servlet.*;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 
 /**

--- a/sstemplates-core/src/test/java/com/carbonfive/sstemplates/servlet/SsTemplateServletTest.java
+++ b/sstemplates-core/src/test/java/com/carbonfive/sstemplates/servlet/SsTemplateServletTest.java
@@ -1,6 +1,6 @@
 package com.carbonfive.sstemplates.servlet;
 
-import javax.servlet.http.*;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.mock.web.*;
 import com.carbonfive.sstemplates.*;
 import com.carbonfive.sstemplates.tags.*;

--- a/sstemplates-core/src/test/java/com/carbonfive/sstemplates/servlet/SsTemplateServletTestBase.java
+++ b/sstemplates-core/src/test/java/com/carbonfive/sstemplates/servlet/SsTemplateServletTestBase.java
@@ -1,8 +1,11 @@
 package com.carbonfive.sstemplates.servlet;
 
 import java.util.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.mock.web.*;
 import com.carbonfive.sstemplates.*;
 import com.carbonfive.sstemplates.tags.*;
@@ -68,7 +71,7 @@ public abstract class SsTemplateServletTestBase
       for (Iterator<String> it = attributes.keySet().iterator(); it.hasNext();)
       {
         String key = (String) it.next();
-        templateContext.getRequest().setAttribute(key,attributes.get(key));
+        request.setAttribute(key,attributes.get(key));
       }
     }
     renderTree.render(templateContext);

--- a/sstemplates-examples/pom.xml
+++ b/sstemplates-examples/pom.xml
@@ -26,13 +26,13 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet.jsp</groupId>
-      <artifactId>javax.servlet.jsp-api</artifactId>
+      <groupId>jakarta.servlet.jsp</groupId>
+      <artifactId>jakarta.servlet.jsp-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -48,9 +48,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <configuration>
-          <scanIntervalSeconds>5</scanIntervalSeconds>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/sstemplates-examples/src/main/java/com/carbonfive/sstemplates/examples/SimpleServlet.java
+++ b/sstemplates-examples/src/main/java/com/carbonfive/sstemplates/examples/SimpleServlet.java
@@ -1,14 +1,17 @@
 package com.carbonfive.sstemplates.examples;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
 
 public class SimpleServlet extends HttpServlet
 {
   private static final long serialVersionUID = 1L;
 
-  public void service(HttpServletRequest request,  HttpServletResponse response)
+  public void service(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException
   {
     request.setAttribute("stringValue", "Ralph");

--- a/sstemplates-examples/src/main/java/com/carbonfive/sstemplates/examples/StandAlone.java
+++ b/sstemplates-examples/src/main/java/com/carbonfive/sstemplates/examples/StandAlone.java
@@ -1,5 +1,6 @@
 package com.carbonfive.sstemplates.examples;
 
+import java.net.URL;
 import java.util.*;
 import java.io.*;
 import org.apache.poi.hssf.usermodel.*;
@@ -9,9 +10,13 @@ public class StandAlone
 {
   public static void main(String args[]) throws Exception
   {
-    File template = new File(System.getProperty("project.root"), "examples/test.templates/standalone.sst");
+    URL templateResource = StandAlone.class.getClassLoader().getResource("standalone.sst");
+    if(templateResource == null) {
+      return;
+    }
+    File template = new File(templateResource.toURI());
 
-    Map<String, Object> context = new HashMap<String, Object>();
+    Map<String, Object> context = new HashMap<>();
     context.put("stringValue", "Ralph");
     context.put("listValue", new String[] { "Sue", "Amy", "Donna" });
 
@@ -19,14 +24,8 @@ public class StandAlone
     HSSFWorkbook workbook = processor.process(template, context);
 
     File xls = new File(System.getProperty("project.root"), "standalone.xls");
-    OutputStream out = new FileOutputStream(xls);
-    try
-    {
+    try (OutputStream out = new FileOutputStream(xls)) {
       workbook.write(out);
-    }
-    finally
-    {
-      out.close();
     }
   }
 }

--- a/sstemplates-examples/src/main/resources/standalone.sst
+++ b/sstemplates-examples/src/main/resources/standalone.sst
@@ -1,0 +1,14 @@
+<workbook xmlns="http://carbonfive.com/schema/sstemplates">
+  <sheet name="StandAlone Example">
+    <row>
+      <cell>Name:</cell>
+      <cell>${ stringValue }</cell>
+    </row>
+    <row>
+      <cell>Names:</cell>
+      <forEach var="name" items="${ listValue }">
+        <cell>${ name }</cell>
+      </forEach>
+    </row>
+  </sheet>
+</workbook>

--- a/sstemplates-examples/src/main/webapp/templates/include.sst
+++ b/sstemplates-examples/src/main/webapp/templates/include.sst
@@ -4,7 +4,7 @@
       <include template="include/include_this.sst"/>
     </row>
     <row>
-      <include template="/test.templates/include/include_this.sst"/>
+      <include template="/templates/include/include_this.sst"/>
     </row>
   </sheet>
 </workbook>


### PR DESCRIPTION
Apache commons-el is end of line and using depricated EL (jsp-api) This commit is replacing commons-el to juel library which supports javax.el, so that we can upgrade java, spring and other to the latest.

One notable change
commons-el was resolving ${param.x} to null even if param bean was not initialized but the juel was throwing nosuchproperty exception and sstemplates was using param so in the variable mapper param is added as a variable with empty map while it is initialized. There won't be any side effects due to this and this is done so that we don't need to change any core logic in sstemplates.