### PR TITLE
Trigger Release build on Publish

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: Release Build
 on:
   release:
     types:
-      - created
+      - published
 env:
   # renovate: datasource=java-version depName=java-jdk
   JAVA_VERSION: '17.0.8+7'


### PR DESCRIPTION
The 'created' type never fires for releases created as a draft.