### PR TITLE
Only have setup-java configure GPG once

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,8 +43,6 @@ jobs:
           server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
       - name: Deploy Release to Maven Central
         run: mvn --batch-mode --no-transfer-progress -Drevision=${GITHUB_REF_NAME##v} -Dtag=${{ github.ref_name }} -Dtree=${{ github.ref_name }} deploy -P release,ossrh
         env:


### PR DESCRIPTION
The setup-java action tries to remove the key twice if it is configured twice.

See: https://github.com/actions/setup-java/issues/128