### PR TITLE
chore(ci): enable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:best-practices",
     ":enableVulnerabilityAlerts",
-    "regexManagers:githubActionsVersions"
+    "regexManagers:githubActionsVersions",
+    ":automergeAll"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
We need to keep the backlog of pending updates clear so that important ones don't get stuck in the rate-limited queue.