### PR TITLE
chore: set maven.compiler.release instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,7 @@
     <url>https://github.com/retailnext/sstemplates/tree/${tree}</url>
   </scm>
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>2.0.0-SNAPSHOT</revision>
     <tag>HEAD</tag>


### PR DESCRIPTION
Specifying a backwards-compatible maven.compiler.source/maven.compiler.target is deprecated in favor of maven.compiler.release, which also takes care of setting the bootclasspath option.

Setting maven.compiler.release instead resolves the following:

   Warning:  system modules path not set in conjunction with -source 17