### PR TITLE
fix: migrate Maven Central publishing to new Central Portal

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,7 +40,7 @@ jobs:
         with: # running setup-java again overwrites the settings.xml
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: central # must match central-publishing-maven-plugin publishingServerId
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
       - name: Deploy Release to Maven Central

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
           <version>3.11.0</version>
         </plugin>
         <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.7.0</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.4</version>
@@ -319,16 +324,21 @@
     </profile>
     <profile>
       <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>ossrh</id>
-          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Summary

- The release workflow was failing with HTTP 402 on `s01.oss.sonatype.org` — Sonatype decommissioned the legacy OSSRH endpoint
- Replaces the old `distributionManagement` OSSRH URLs with the new `central-publishing-maven-plugin` targeting `central.sonatype.com`
- Updates the `setup-java` step in the release workflow to configure a `central` server ID (matching the plugin's `publishingServerId`)

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-create the `v2.0.0-rc.2` release (or create `v2.0.0-rc.3`) to trigger the release workflow
- [ ] Confirm the "Deploy Release to Maven Central" step succeeds and the artifact appears in central.sonatype.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)