### PR TITLE
chore(ci): redirect test output to file and add JUnit test reporter

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       contents: read
       packages: write
     steps:
@@ -29,6 +30,11 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --no-transfer-progress --update-snapshots verify
+      - name: Test Report
+        if: ${{ always() }}
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
       - name: Extract Maven project version
         run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
         id: project

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,6 +9,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Maven
@@ -23,3 +26,8 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify
+      - name: Test Report
+        if: ${{ always() }}
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Release
     permissions:
+      checks: write
       contents: read
       packages: write
     if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
@@ -49,3 +50,8 @@ jobs:
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      - name: Test Report
+        if: ${{ always() }}
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.6</version>
+          <configuration>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Problem

The `SecurityTest.testXxePreventionRejectsDoctypeDecl` test verifies that XXE attacks
are blocked by asserting that a `SsTemplateException` is thrown when a DOCTYPE
declaration is encountered. The test passes correctly, but it produces ~200 lines of
stack trace output in CI logs from commons-digester3's internal error logging.

This happens because the Digester's SAX error handler logs the `SAXParseException` at
ERROR level (with full stack trace) *before* the exception propagates up to the test's
`assertThrows`. The result is a CI log that looks alarming — a wall of red `ERROR`
messages and tracebacks — despite all 60 tests passing successfully.

## Solution

**Redirect test output to file:** Add `redirectTestOutputToFile=true` to the
Maven Surefire plugin configuration. Test stdout/stderr is captured in per-test
`.txt` files under `target/surefire-reports/` instead of being dumped to the
CI console. This keeps logs clean for passing builds.

**Add a JUnit test reporter:** Add `mikepenz/action-junit-report` to all workflows
(PR, main, release) with `if: always()`. When a test *does* fail, the action parses
Surefire's XML reports and posts results as GitHub check annotations — including the
captured output from the per-test files. This ensures failures remain fully diagnosable
without requiring noisy output during normal successful runs.

## Changes

- `pom.xml`: Add `<redirectTestOutputToFile>true</redirectTestOutputToFile>` to
  `maven-surefire-plugin` in `<pluginManagement>`
- `.github/workflows/build-pr.yml`: Add test reporter step + `checks: write` permission
- `.github/workflows/build-main.yml`: Add test reporter step + `checks: write` permission
- `.github/workflows/build-release.yml`: Add test reporter step + `checks: write` permission
